### PR TITLE
chore: add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+demo/
+demo-ng/


### PR DESCRIPTION
Prevents the demo projects from being published and thus included when the project is installed via NPM.