### PR TITLE
fix(android): remove OrientationListener

### DIFF
--- a/image-swipe.android.ts
+++ b/image-swipe.android.ts
@@ -250,7 +250,6 @@ class ZoomImageView extends android.widget.ImageView {
     private _totalTranslateX = [0]; // HACK: for some reason only number private variable does not work, use Array and set the value to the first item in the array. 
     private _totalTranslateY = [0]; // HACK: for some reason only number private variable does not work, use Array and set the value to the first item in the array. 
 
-    private _orientationChangeListener: OrientationListener;
     private _onCanScrollChangeListener: OnCanScrollChangeListenerImplementation;
 
     constructor(private _owner: WeakRef<ImageSwipe>) {
@@ -269,9 +268,6 @@ class ZoomImageView extends android.widget.ImageView {
             // tslint:disable-next-line:no-empty
             onScaleEnd: () => { }
         }));
-
-        this._orientationChangeListener = new OrientationListener(context, that);
-        this._orientationChangeListener.enable();
 
         return __native(this);
     }


### PR DESCRIPTION
Resolves an issue where the zoom & position state of the plugin would regularly reset whenever a device was not held on a flat surface, causing a poor user experience.

Ultimately, a solution which keeps the listener in place but does not reset the state unless the orientation of the device changes and the app supports changing the orientation would be preferred.